### PR TITLE
xc_fasm: add wrapper around fasm2frames and frames2bit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,5 +37,5 @@ setuptools.setup(
         "fasm@git+git://github.com/SymbiFlow/fasm.git#egg=fasm",
     ],
     entry_points={
-        'console_scripts': ['fasm2frames=xc_fasm.fasm2frames:main'],
+        'console_scripts': ['xcfasm=xc_fasm.xc_fasm:main'],
     })

--- a/tests/test_fasm2frames.py
+++ b/tests/test_fasm2frames.py
@@ -18,7 +18,7 @@ import unittest
 import tempfile
 
 import prjxray
-import xc_fasm.fasm2frames as fasm2frames
+from xc_fasm.fasm2frames import fasm2frames
 
 from textx.exceptions import TextXSyntaxError
 
@@ -72,23 +72,23 @@ class TestStringMethods(unittest.TestCase):
         with open(self.filename_test_data(fname)) as f:
             return f.read()
 
-    def fasm2frames(self, fin_data, **kw):
+    def run_fasm2frames(self, fin_data, **kw):
         with tempfile.NamedTemporaryFile(suffix='.fasm') as fin:
             fin.write(fin_data.encode('utf-8'))
             fin.flush()
 
             fout = StringIO()
-            fasm2frames.run(
+            fasm2frames(
                 self.filename_test_data('db'), "xc7", fin.name, fout, **kw)
 
             return fout.getvalue()
 
     def test_lut(self):
         '''Simple smoke test on just the LUTs'''
-        self.fasm2frames(self.get_test_data('lut.fasm'))
+        self.run_fasm2frames(self.get_test_data('lut.fasm'))
 
     def bitread_frm_equals(self, frm_fn, bitread_fn):
-        fout = self.fasm2frames(self.get_test_data(frm_fn))
+        fout = self.run_fasm2frames(self.get_test_data(frm_fn))
 
         # Build a list of output used bits
         bits_out = frm2bits(fout)
@@ -114,18 +114,18 @@ class TestStringMethods(unittest.TestCase):
     # Same check as above, but isolated test case
     def test_opkey_01_default(self):
         '''Optional key with binary omitted value should produce valid result'''
-        self.fasm2frames("CLBLM_L_X10Y102.SLICEM_X0.SRUSEDMUX")
+        self.run_fasm2frames("CLBLM_L_X10Y102.SLICEM_X0.SRUSEDMUX")
 
     @unittest.skip
     def test_opkey_01_1(self):
-        self.fasm2frames("CLBLM_L_X10Y102.SLICEM_X0.SRUSEDMUX 1")
+        self.run_fasm2frames("CLBLM_L_X10Y102.SLICEM_X0.SRUSEDMUX 1")
 
     @unittest.skip
     def test_opkey_enum(self):
         '''Optional key with enumerated value should produce syntax error'''
         try:
             # CLBLM_L.SLICEM_X0.AMUXFF.O6 !30_06 !30_07 !30_08 30_11
-            self.fasm2frames("CLBLM_L_X10Y102.SLICEM_X0.AFFMUX.O6")
+            self.run_fasm2frames("CLBLM_L_X10Y102.SLICEM_X0.AFFMUX.O6")
             self.fail("Expected syntax error")
         except TextXSyntaxError:
             pass
@@ -137,7 +137,7 @@ class TestStringMethods(unittest.TestCase):
     def test_badkey(self):
         '''Bad key should throw syntax error'''
         try:
-            self.fasm2frames("CLBLM_L_X10Y102.SLICEM_X0.SRUSEDMUX 2")
+            self.run_fasm2frames("CLBLM_L_X10Y102.SLICEM_X0.SRUSEDMUX 2")
             self.fail("Expected syntax error")
         except TextXSyntaxError:
             pass
@@ -146,7 +146,7 @@ class TestStringMethods(unittest.TestCase):
     def test_dupkey(self):
         '''Duplicate key should throw syntax error'''
         try:
-            self.fasm2frames("""\
+            self.run_fasm2frames("""\
 CLBLM_L_X10Y102.SLICEM_X0.SRUSEDMUX 0
 CLBLM_L_X10Y102.SLICEM_X0.SRUSEDMUX 1
 """)
@@ -159,11 +159,11 @@ CLBLM_L_X10Y102.SLICEM_X0.SRUSEDMUX 1
         '''Verify sparse equivalent to normal encoding'''
         frm_fn = 'lut_int.fasm'
 
-        fout_sparse_txt = self.fasm2frames(
+        fout_sparse_txt = self.run_fasm2frames(
             self.get_test_data(frm_fn), sparse=True)
         bits_sparse = frm2bits(fout_sparse_txt)
 
-        fout_full_txt = self.fasm2frames(
+        fout_full_txt = self.run_fasm2frames(
             self.get_test_data(frm_fn), sparse=False)
         bits_full = frm2bits(fout_full_txt)
 

--- a/xc_fasm/fasm2frames.py
+++ b/xc_fasm/fasm2frames.py
@@ -108,14 +108,14 @@ def get_iob_sites(db, tile_name):
         yield "IOB_Y{}".format(site_y)
 
 
-def run(db_root,
-        part,
-        filename_in,
-        f_out,
-        sparse=False,
-        roi=None,
-        debug=False,
-        emit_pudc_b_pullup=False):
+def fasm2frames(db_root,
+                part,
+                filename_in,
+                f_out=None,
+                sparse=False,
+                roi=None,
+                debug=False,
+                emit_pudc_b_pullup=False):
     db = Database(db_root, part)
     assembler = fasm_assembler.FasmAssembler(db)
 
@@ -268,7 +268,10 @@ def run(db_root,
     if debug:
         dump_frames_sparse(frames)
 
-    dump_frm(f_out, frames)
+    if f_out is not None:
+        dump_frm(f_out, frames)
+
+    return frames
 
 
 def main():
@@ -298,7 +301,8 @@ def main():
         help='Output FPGA frame (.frm) file')
 
     args = parser.parse_args()
-    run(db_root=args.db_root,
+    fasm2frames(
+        db_root=args.db_root,
         part=args.part,
         filename_in=args.fn_in,
         f_out=open(args.fn_out, 'w'),

--- a/xc_fasm/xc_fasm.py
+++ b/xc_fasm/xc_fasm.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017-2020  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
+import argparse
+import subprocess
+import os
+
+from prjxray import util
+from fasm2frames import fasm2frames
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=
+        'Convert FPGA configuration description ("FPGA assembly") into binary frame equivalent'
+    )
+
+    util.db_root_arg(parser)
+    util.part_arg(parser)
+    parser.add_argument('--part_file', required=True, help="Part YAML file.")
+    parser.add_argument(
+        '--sparse', action='store_true', help="Don't zero fill all frames")
+    parser.add_argument(
+        '--roi',
+        help="ROI design.json file defining which tiles are within the ROI.")
+    parser.add_argument(
+        '--emit_pudc_b_pullup',
+        help="Emit an IBUF and PULLUP on the PUDC_B pin if unused",
+        action='store_true')
+    parser.add_argument(
+        '--debug', action='store_true', help="Print debug dump")
+    parser.add_argument('--fn_in', help='Input FPGA assembly (.fasm) file')
+    parser.add_argument('--bit_out', help='Output FPGA bitstream (.bit) file')
+    parser.add_argument(
+        '--frm_out',
+        default='/dev/stdout',
+        nargs='?',
+        help='Output FPGA frame (.frm) file')
+
+    args = parser.parse_args()
+    fasm2frames(
+        db_root=args.db_root,
+        part=args.part,
+        filename_in=args.fn_in,
+        f_out=open(args.frm_out, 'w'),
+        sparse=args.sparse,
+        roi=args.roi,
+        debug=args.debug,
+        emit_pudc_b_pullup=args.emit_pudc_b_pullup)
+
+    result = subprocess.check_output(
+        "xc7frames2bit --frm_file {} --output_file {} --part_name {} --part_file {}"
+        .format(args.frm_out, args.bit_out, args.part, args.part_file),
+        shell=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/xc_fasm/xc_fasm.py
+++ b/xc_fasm/xc_fasm.py
@@ -14,7 +14,7 @@ import subprocess
 import os
 
 from prjxray import util
-from fasm2frames import fasm2frames
+from .fasm2frames import fasm2frames
 
 
 def main():


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR builds a wrapper around fasm2frames and frames2bit, so that we can produce the final bitstream with only one command invocation.