### PR TITLE
fasm2frames: update pudc IN_ONLY fasm line

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pyyaml
 git+https://github.com/SymbiFlow/fasm.git#egg=fasm
 git+https://github.com/SymbiFlow/prjxray.git#egg=prjxray
 -e .

--- a/tests/test_data/db/mapping/devices.yaml
+++ b/tests/test_data/db/mapping/devices.yaml
@@ -1,0 +1,2 @@
+"xc7":
+    fabric: "xc7"

--- a/tests/test_data/db/mapping/parts.yaml
+++ b/tests/test_data/db/mapping/parts.yaml
@@ -1,0 +1,4 @@
+"xc7":
+    device: "xc7"
+    package: ""
+    speedgrade: ""

--- a/xc_fasm/fasm2frames.py
+++ b/xc_fasm/fasm2frames.py
@@ -193,7 +193,7 @@ def fasm2frames(db_root,
         # unclear how to know which IOSTANDARD to use.
         missing_features = []
         for line in fasm.parse_fasm_string("""
-{tile}.{site}.LVCMOS12_LVCMOS15_LVCMOS18_LVCMOS25_LVCMOS33_LVTTL_SSTL135_SSTL15.IN_ONLY
+{tile}.{site}.LVCMOS12_LVCMOS15_LVCMOS18_LVCMOS25_LVCMOS33_LVDS_25_LVTTL_SSTL135_SSTL15_TMDS_33.IN_ONLY
 {tile}.{site}.LVCMOS25_LVCMOS33_LVTTL.IN
 {tile}.{site}.PULLTYPE.PULLUP
 """.format(


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR updates the FASM line after the LVDS and TMDS addition to the DB. It is required for https://github.com/SymbiFlow/symbiflow-arch-defs/pull/2072